### PR TITLE
fastcomposer개선과 기능 병합

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+yarn.lock
 
 # Editor directories and files
 .idea

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^0.18.0",
+    "draggable-vue-directive": "^2.0.6",
     "lodash": "^4.17.11",
     "marked": "^0.6.2",
     "moment": "^2.24.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lodash": "^4.17.11",
     "marked": "^0.6.2",
     "moment": "^2.24.0",
-    "vue": "^2.6.10"
+    "vue": "^2.6.10",
+    "vue-smooth-dnd": "^0.8.0"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.7.0",

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,9 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Sans+KR:400,700">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css"
         integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css">
+<!--  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css">-->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+        integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
   <style>
     html {
       box-sizing: border-box;

--- a/src/block-item.vue
+++ b/src/block-item.vue
@@ -16,12 +16,7 @@
     <button @click="$emit('remove', block)">
       <i class="fas fa-trash-alt"></i>
     </button>
-    <button @click="$emit('up', block)">
-      <i class="fas fa-arrow-up"></i>
-    </button>
-    <button @click="$emit('down', block)">
-      <i class="fas fa-arrow-down"></i>
-    </button>
+    <button class="row-drag-handle"><i class="fas fa-bars"></i></button>
   </div>
 </template>
 

--- a/src/composer.vue
+++ b/src/composer.vue
@@ -1,8 +1,22 @@
 <template>
   <div class="fc-composer">
-    <sidebar-pane :layouts="layoutArray" @select="onSelectLayout"></sidebar-pane>
-    <editor-pane :blocks="blocks" ref="editor" @select="onSelectBlock" @save="save"></editor-pane>
-    <preview-pane :blocks="blocks" ref="preview"></preview-pane>
+    <sidebar-pane
+      :layouts="layoutArray"
+      v-if="isLayerKits"
+      @select="onSelectLayout"
+    ></sidebar-pane>
+    <editor-pane
+      :blocks="blocks"
+      v-if="isLayers"
+      ref="editor"
+      @select="onSelectBlock"
+      @save="save"
+    ></editor-pane>
+    <preview-pane
+      :blocks="blocks"
+      @toggleLayerKits="toggleLayerKits"
+      @toggleLayers="onToggleLayers"
+      ref="preview"></preview-pane>
   </div>
 </template>
 
@@ -34,6 +48,8 @@ export default {
   },
   data() {
     return {
+      isLayerKits: true,
+      isLayers: true,
       layoutArray: [],
       layoutMap: {},
       blocks: [],
@@ -104,6 +120,12 @@ export default {
           console.error('bad or missing value', err);
           this.blocks = [];
         });
+    },
+    toggleLayerKits() {
+      this.isLayerKits = !this.isLayerKits;
+    },
+    onToggleLayers() {
+      this.isLayers = !this.isLayers;
     },
   },
   async created() {

--- a/src/composer.vue
+++ b/src/composer.vue
@@ -14,6 +14,8 @@
     ></editor-pane>
     <preview-pane
       :blocks="blocks"
+      :isLayers="isLayers"
+      :isLayerKits="isLayerKits"
       @toggleLayerKits="toggleLayerKits"
       @toggleLayers="onToggleLayers"
       ref="preview"></preview-pane>

--- a/src/editor-pane.vue
+++ b/src/editor-pane.vue
@@ -13,7 +13,6 @@
             @select="selectBlock(block)"
             @remove="removeBlock(block)"
           ></block-item>
-          <block-form v-if="block === activeBlock" :block="block" :key="block.id + '-form'"></block-form>
         </Draggable>
       </Container>
     </main>
@@ -24,7 +23,6 @@
 import { Container, Draggable } from "vue-smooth-dnd";
 import marked from 'marked';
 import BlockItem from './block-item.vue';
-import BlockForm from './block-form.vue';
 
 const applyDrag = (arr, dragResult) => {
   const { removedIndex, addedIndex, payload } = dragResult;
@@ -48,13 +46,10 @@ export default {
   name: 'editor-pane',
   components: {
     BlockItem,
-    BlockForm,
     Container,
     Draggable,
   },
-  props: {
-    blocks: Array,
-  },
+  props: ['blocks'],
   data() {
     return {
       activeBlock: null,

--- a/src/preview-pane.vue
+++ b/src/preview-pane.vue
@@ -2,6 +2,10 @@
   <div class="fc-preview">
     <header>
       <h3>preview</h3>
+      <div class="btn-group">
+        <button type="button" class="btn btn-sm btn-outline-secondary" @click="toggleLayerKits">Layer Kits on/off</button>
+        <button type="button" class="btn btn-sm btn-outline-secondary" @click="toggleLayers">Layers on/off</button>
+      </div>
       <button @click="zoomIn"><i class="fas fa-search-plus"></i></button>
       <button @click="zoomOut"><i class="fas fa-search-minus"></i></button>
     </header>
@@ -43,6 +47,12 @@ export default {
     zoomOut() {
       this.zoom = Math.max(this.zoom - 0.25, 0.25);
     },
+    toggleLayerKits() {
+      this.$emit('toggleLayerKits');
+    },
+    toggleLayers() {
+      this.$emit('toggleLayers');
+    }
   },
 };
 </script>

--- a/src/preview-pane.vue
+++ b/src/preview-pane.vue
@@ -3,6 +3,7 @@
     <header>
       <h3>preview</h3>
       <div class="btn-group">
+        <button type="button" @click="requestFullscreen"><i class="fas fa-expand"></i></button>
         <button type="button" @click="toggleLayerKits"><i class="fas" v-bind:class="[isLayerKits ? 'fa-toggle-on' : 'fa-toggle-off']"></i></button>
         <button type="button" @click="toggleLayers"><i class="fas" v-bind:class="[isLayers ? 'fa-toggle-on' : 'fa-toggle-off']"></i></button>
       </div>
@@ -33,7 +34,6 @@ import BlockPreview from './block-preview.vue';
 import BlockForm from './block-form.vue';
 import { Draggable } from 'draggable-vue-directive';
 
-
 export default {
   name: 'preview-pane',
   directives: {
@@ -51,6 +51,15 @@ export default {
     };
   },
   methods: {
+    requestFullscreen() {
+      const targetElement = this.$el.getElementsByTagName('main')[0];
+      const requestFullscreen = (targetElement.requestFullscreen
+        || targetElement.msRequestFullscreen
+        || targetElement.mozRequestFullScreen
+        || targetElement.webkitRequestFullscreen).bind(targetElement);
+
+      requestFullscreen();
+    },
     selectBlock(block) {
       this.activeBlock = block;
     },
@@ -103,6 +112,9 @@ export default {
     overflow: scroll;
     padding: 1rem;
     transform-origin: top left;
+    &:fullscreen {
+      background-color: #ffffff;
+    }
   }
 }
 </style>

--- a/src/preview-pane.vue
+++ b/src/preview-pane.vue
@@ -9,6 +9,14 @@
       <button @click="zoomIn"><i class="fas fa-search-plus"></i></button>
       <button @click="zoomOut"><i class="fas fa-search-minus"></i></button>
     </header>
+    <div v-draggable v-show="activeBlock" style="position:fixed;border:0.1rem solid;background-color:#fff;">
+      <div style="position:relative; margin: 1rem;">
+        <div class="btn-group" style="position: absolute; right: 0;">
+          <button type="button" @click="unSelectBlack"><i class="far fa-window-close"></i></button>
+        </div>
+        <block-form v-if="activeBlock" :block="activeBlock" :key="activeBlock.id + '-form'"></block-form>
+      </div>
+    </div>
     <main :style="{ zoom }">
       <block-preview
         v-for="(block, blockIndex) in blocks"
@@ -22,11 +30,18 @@
 
 <script>
 import BlockPreview from './block-preview.vue';
+import BlockForm from './block-form.vue';
+import { Draggable } from 'draggable-vue-directive';
+
 
 export default {
   name: 'preview-pane',
+  directives: {
+    Draggable,
+  },
   components: {
     BlockPreview,
+    BlockForm,
   },
   props: ['blocks', 'isLayers', 'isLayerKits'],
   data() {
@@ -38,6 +53,9 @@ export default {
   methods: {
     selectBlock(block) {
       this.activeBlock = block;
+    },
+    unSelectBlack() {
+      this.activeBlock = null;
     },
     zoomIn() {
       this.zoom = Math.min(this.zoom + 0.25, 2);

--- a/src/preview-pane.vue
+++ b/src/preview-pane.vue
@@ -3,8 +3,8 @@
     <header>
       <h3>preview</h3>
       <div class="btn-group">
-        <button type="button" class="btn btn-sm btn-outline-secondary" @click="toggleLayerKits">Layer Kits on/off</button>
-        <button type="button" class="btn btn-sm btn-outline-secondary" @click="toggleLayers">Layers on/off</button>
+        <button type="button" @click="toggleLayerKits"><i class="fas" v-bind:class="[isLayerKits ? 'fa-toggle-on' : 'fa-toggle-off']"></i></button>
+        <button type="button" @click="toggleLayers"><i class="fas" v-bind:class="[isLayers ? 'fa-toggle-on' : 'fa-toggle-off']"></i></button>
       </div>
       <button @click="zoomIn"><i class="fas fa-search-plus"></i></button>
       <button @click="zoomOut"><i class="fas fa-search-minus"></i></button>
@@ -28,9 +28,7 @@ export default {
   components: {
     BlockPreview,
   },
-  props: {
-    blocks: Array,
-  },
+  props: ['blocks', 'isLayers', 'isLayerKits'],
   data() {
     return {
       activeBlock: null,


### PR DESCRIPTION
아직 vuejs가 익숙하지 않은단계라 코드보단 UX/UI중심으로 개선중입니다.

**작업완료(코드 변경전, 네이밍 변경전 기준)** 
editor -> BlockItem
- (#33)Drag&drop 지원(기존 up, down 버튼 제거)
preview 
- (#16)layouts, editor show/hide 상태 변경 버튼 추가
- fullscreen mode 추가
- (#22)BlockForm 하나로만 존재하며, 사용자가 원하는 위치로 draggable지원

**작업진행 및 예정**
- 선작업 (#10, #26, #28 -> 기능병합)
- (#35)layer 컴포넌트 제거
- vuejs 폴더 트리 개선
- 컴포넌트 네이밍 변경

**내용 추가 작업예정(5. 24)**
- device 모드 지원(반응형, 모바일, 패드, pc등)
- (#33)dnd 아용하여 지금의 layout 리스트를 최종 제거하는 방안 고민
- API지원(callback에 받은 preview data set , get)
- preview 모달 팝업 형태로 개선
- (#34)preview element안에서 편집, 삭제 추가