### PR TITLE
Add keyboard support

### DIFF
--- a/src/components/content/aside/layers/layers.vue
+++ b/src/components/content/aside/layers/layers.vue
@@ -1,7 +1,19 @@
 <template>
   <Container @drop="drop" :get-ghost-parent="getGhostParent">
     <Draggable v-for="(layer, index) in layers" :key="index">
-      <div class="__item" :class="{'__item--active': index === currentLayerIndex}">
+      <div
+        class="__item"
+        :class="{ '__item--active': index === currentLayerIndex }"
+        tabindex="0"
+        @focus="select(index)"
+        @keydown.exact.enter.prevent="focusEditor"
+        @keydown.exact.up.prevent="select(currentLayerIndex - 1)"
+        @keydown.exact.down.prevent="select(currentLayerIndex + 1)"
+        @keydown.exact.page-up.prevent="select(currentLayerIndex - 5)"
+        @keydown.exact.page-down.prevent="select(currentLayerIndex + 5)"
+        @keydown.exact.home.prevent="select(0)"
+        @keydown.exact.end.prevent="select(layers.length - 1)"
+      >
         <div class="__item__group" v-if="layer.layout" @click="select(index)">
           <img :src="layer.layout.icon" alt="" />
           <span class="__item__group__info">
@@ -67,7 +79,8 @@
     },
     methods: {
       select(index) {
-        EventBus.$emit('selected-layer', index);
+        const newIndex = Math.min(Math.max(index, 0), this.layers.length - 1);
+        EventBus.$emit('selected-layer', newIndex);
         EventBus.$emit('move-selected-layer');
       },
       drop(dropResult) {
@@ -79,8 +92,20 @@
       },
       removeLayer(index) {
         EventBus.$emit('remove-layer', index);
-      }
-    }
+      },
+      focus() {
+        // XXX: focus the selected layer
+        this.$el.focus();
+        const el = this.$el.querySelector('.__item--active');
+        if (el) {
+          el.focus();
+        }
+      },
+      focusEditor() {
+        // XXX: focus to editor
+        EventBus.$emit('focus-editor');
+      },
+    },
   }
 </script>
 <style lang="scss" scoped>
@@ -88,6 +113,7 @@
   .__item {
     position: relative;
     border: 3px solid #ffffff;
+    cursor: pointer;
     &--active {
       border: 3px solid #f74982;
     }

--- a/src/components/content/layouts/layouts.vue
+++ b/src/components/content/layouts/layouts.vue
@@ -1,10 +1,21 @@
 <template>
   <div class="fc-layout" v-if="flag"
     :style="layoutStyle"
+       tabindex="0"
+       @keydown.exact.enter.prevent="selected(layouts[layoutIndex])"
+       @keydown.exact.up.prevent="focus(layoutIndex - 1)"
+       @keydown.exact.down.prevent="focus(layoutIndex + 1)"
+       @keydown.exact.home.prevent="focus(0)"
+       @keydown.exact.end.prevent="focus(layouts.length - 1)"
+       @keydown.exact.page-up.prevent="focus(layoutIndex - 5)"
+       @keydown.exact.page-down.prevent="focus(layoutIndex + 5)"
+       @keydown.exact.esc.prevent="toggle"
   >
     <ul class="fc-layout__list">
       <li v-for="(layout, index) in layouts" :key="index">
-        <button class="fc-layout__list__item" @click="selected(layout)">
+        <button class="fc-layout__list__item" @click="selected(layout)"
+                @focus="focus(index)"
+                :class="{active: index === layoutIndex}">
           <img :src="layout.icon" alt="" />
           <span class="fc-layout__list__item__info">
           <strong class="fc-layout__list__item__name">{{ layout.id }}</strong>
@@ -32,6 +43,8 @@
     },
     data() {
       return {
+        layoutIndex: 0,
+        savedFocus: null,
         flag: false
       }
     },
@@ -41,10 +54,27 @@
          * composer에서 layers에 push가 일어나며, 추가된 layer가 선택된다.
          */
         EventBus.$emit('add-layer', layout);
+        this.flag = false;
       },
       toggle() {
         this.flag = !this.flag;
-      }
+        this.$nextTick(() => {
+          if(this.flag) {
+            // XXX: save current focus to restore focus for cancel
+            this.savedFocus = document.activeElement;
+            this.$el.focus();
+          } else {
+            // XXX: restore focus if possible
+            if (this.savedFocus) {
+              this.savedFocus.focus();
+              this.savedFocus = null;
+            }
+          }
+        });
+      },
+      focus(index) {
+        this.layoutIndex = Math.min(Math.max(index, 0), this.layouts.length - 1);
+      },
     },
   }
 </script>
@@ -103,6 +133,10 @@
           display: block;
           margin-bottom: 0.5rem;
         }
+      }
+
+      .active {
+        border: 2px solid red;
       }
     }
     li {

--- a/src/components/content/preview/layer-content.vue
+++ b/src/components/content/preview/layer-content.vue
@@ -5,12 +5,14 @@
       :id="layer.id"
       :class="['fc-layout-' + layer.layout.id, { 'fc-selected': isSelected }]"
       v-html="html"
+      @click="select"
     ></div>
   </div>
 </template>
 
 <script>
 import marked from 'marked';
+import EventBus from '../../../event-bus/event-bus';
 
 export default {
   props: {
@@ -33,6 +35,11 @@ export default {
         }
       }
       return this.layer.layout.templateFunc({ $markdown: marked, ...this.layer.values });
+    },
+  },
+  methods: {
+    select() {
+      EventBus.$emit('selected-layer', this.index);
     },
   },
 };

--- a/src/components/content/preview/preview.vue
+++ b/src/components/content/preview/preview.vue
@@ -1,5 +1,14 @@
 <template>
-  <div class="fc-preview">
+  <div class="fc-preview"
+       tabindex="0"
+       @keydown.exact.enter.prevent="focusEditor"
+       @keydown.exact.up.prevent="select(index-1)"
+       @keydown.exact.down.prevent="select(index+1)"
+       @keydown.exact.home.prevent="select(0)"
+       @keydown.exact.end.prevent="select(layers.length - 1)"
+       @keydown.exact.page-up.prevent="select(index - 5)"
+       @keydown.exact.page-down.prevent="select(index + 5)"
+  >
     <div class="fc-preview__container">
       <layer-content
         v-for="(layer, layerIndex) in layers"
@@ -54,6 +63,17 @@
       }
     },
     methods: {
+      select(index) {
+        const newIndex = Math.min(Math.max(index, 0), this.layers.length - 1);
+        EventBus.$emit('selected-layer', newIndex);
+        EventBus.$emit('move-selected-layer');
+      },
+      focus() {
+        this.$el.focus();
+      },
+      focusEditor() {
+        EventBus.$emit('focus-editor');
+      },
       save() {
         console.log(this.html);
         EventBus.$emit('save');

--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -64,6 +64,7 @@
 </template>
 
 <script>
+  import EventBus from './../../event-bus/event-bus';
   import FileUpload from './file-upload.vue';
 
   export default {
@@ -82,6 +83,26 @@
       upload(name, url) {
         this.layer.values[name] = url;
       },
+      focus() {
+        // XXX: focus the first input element and select all text if possible
+        this.$nextTick(() => {
+          // XXX: reset editor pane scroll position to top
+          this.$el.scrollTop = 0;
+          this.$el.parentElement.scrollTop = 0;
+          this.$el.focus();
+          const el = this.$el.querySelector('input,textarea,select,button');
+          console.log(el);
+          if (el) {
+            el.focus();
+            if (typeof el.select === 'function') {
+              el.select();
+            }
+          }
+        });
+      },
+    },
+    mounted() {
+      EventBus.$on('focus-editor', () => this.focus());
     },
   };
 </script>


### PR DESCRIPTION
최소한의 수정으로 단축키를 지원합니다.

- alt+shift+left: focus to 레이어 편집
- alt+shift+right: focus to 레이어 목록
- alt+shift+up: focus to 미리보기
- alt+shift+down: toggle 레이아웃 목록(popup)
- up/down/home/end/pageup/pagedown/enter: (레이어 목록 & 레이아웃 목록) 위/아래/첫/끝/... 선택 & 편집
- esc: 레이아웃 목록(popup) 닫기