### PR TITLE
select the dropped layer after drag and drop

### DIFF
--- a/src/components/content/aside/layers/layers.vue
+++ b/src/components/content/aside/layers/layers.vue
@@ -5,7 +5,6 @@
         class="__item"
         :class="{ '__item--active': index === currentLayerIndex }"
         tabindex="0"
-        @focus="select(index)"
         @keydown.exact.enter.prevent="focusEditor"
         @keydown.exact.up.prevent="select(currentLayerIndex - 1)"
         @keydown.exact.down.prevent="select(currentLayerIndex + 1)"
@@ -14,7 +13,7 @@
         @keydown.exact.home.prevent="select(0)"
         @keydown.exact.end.prevent="select(layers.length - 1)"
       >
-        <div class="__item__group" v-if="layer.layout" @click="select(index)">
+        <div class="__item__group" v-if="layer.layout" @click="select(index, $event)">
           <img :src="layer.layout.icon" alt="" />
           <span class="__item__group__info">
             <strong class="__item__group__name">{{ layer.layout.id }}</strong>
@@ -106,9 +105,9 @@
       getLayoutStateIconStyle({ hidden }) {
         return hidden ? 'visibility_off' : 'visibility';
       },
-      select(index) {
+      select(index, event) {
         const newIndex = Math.min(Math.max(index, 0), this.layers.length - 1);
-        EventBus.$emit('selected-layer', newIndex);
+        EventBus.$emit('selected-layer', newIndex, event && event.type === 'click');
         EventBus.$emit('move-selected-layer');
       },
       drop(dropResult) {

--- a/src/components/content/aside/layers/layers.vue
+++ b/src/components/content/aside/layers/layers.vue
@@ -113,6 +113,8 @@
       drop(dropResult) {
         this.dropResult = dropResult;
         this.layers = this.applyDrag;
+        EventBus.$emit('selected-layer', dropResult.addedIndex, true);
+        EventBus.$emit('move-selected-layer');
       },
       getGhostParent(){
         return document.body;

--- a/src/views/composer.vue
+++ b/src/views/composer.vue
@@ -234,8 +234,16 @@
       clearMessageToast() {
         this.notification.message = '';
       },
-      onUpdateCurrentLayerIndex(index) {
+      onUpdateCurrentLayerIndex(index, isClick) {
         this.currentLayerIndex = index;
+
+        if (isClick !== true) {
+          const [, el] = this.$el.querySelectorAll('.fc-aside__container');
+
+          if (this.$el.querySelector('.smooth-dnd-container').children.length) {
+            el.scrollTop = this.$el.querySelector('.smooth-dnd-container').children[index].offsetTop;
+          }
+        }
       },
       onAddLayer(layout) {
         if (this.currentLayerIndex < 0) {


### PR DESCRIPTION
컴포저 일부 사용성 개선됩니다.
1. 미리보기 화면에서 레이어 선택 시 우측 레이어 리스트가 선택된 위치로 이동합니다.
2. 레이어 리스트에서 dnd를 하는 경우 drop된 레이어가 선택되도록 변경합니다.
