### PR TITLE
fix notification message bug(V2-420)

### DIFF
--- a/src/assets/scss/utils/_variable.scss
+++ b/src/assets/scss/utils/_variable.scss
@@ -25,7 +25,7 @@ $p-large: 80px;
 $gutter-small: 10px;
 $gutter-large: 20px;
 
-$header-size: 6rem;
+$header-size: 8rem;
 $sidebar-size: 28rem;
 
 $font-base: 'Montserrat', 'Noto Sans KR', sans-serif;

--- a/src/components/common/message-toast.vue
+++ b/src/components/common/message-toast.vue
@@ -1,6 +1,6 @@
 <template>
   <transition name="message-toast">
-    <div class="fc-message-toast" v-show="isActive">
+    <div class="fc-message-toast" v-show="isActive" :class="'fc-' + type">
       <p class="fc-message-toast__content">
         {{ message }}
       </p>
@@ -17,6 +17,12 @@
         default () {
           return '';
         }
+      },
+      type: {
+        type: String,
+        default() {
+          return 'default'
+        }
       }
     },
     data () {
@@ -31,15 +37,30 @@
           setTimeout(() => {
             this.isActive = false;
             EventBus.$emit('clear');
-          }, 1500);
+          }, 2000);
         }
       }
     }
   }
 </script>
 
-<style lang="scss" scope>
+<style lang="scss" scoped>
+  .fc-success {
+    background: #2D9E2E;
+  }
+  .fc-error {
+    background: #FFB100;
+  }
   .fc-message-toast {
+    position: absolute;
+    top: 0;
+    left: 0;
+    display: flex;
+    width: 100%;
+    height: 8rem;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
     &__content {
       color: #ffffff;
       text-align: center;

--- a/src/components/content/layouts/layouts.vue
+++ b/src/components/content/layouts/layouts.vue
@@ -94,11 +94,12 @@
   }
 
   .fc-layout {
+    background-color: red;
     display: flex;
     position: fixed;
-    top:6rem;
+    top: 8rem;
     bottom:0;
-    right: 2.5rem;
+    right: 4rem;
     width: 40rem;
     padding-bottom:2rem;
     z-index: 9999;

--- a/src/components/content/preview/preview.vue
+++ b/src/components/content/preview/preview.vue
@@ -114,8 +114,8 @@
     &__save {
       position: fixed;
       right: 1.75rem;
-      top: .75rem;
-      z-index: 101;
+      top: 2.5rem;
+      z-index: 102;
       width: 4.5rem;
       height: 4.5rem;
       background-color: $accent;

--- a/src/components/header/header.vue
+++ b/src/components/header/header.vue
@@ -10,7 +10,6 @@
           </button>
         </li>
       </ul>
-      <message-toast :message="notificationMessage"/>
     </div>
     <div class="fc-header__right">
       <div class="fc-header__info">
@@ -26,13 +25,9 @@
 
 <script>
   import EventBus from '../../event-bus/event-bus';
-  import MessageToast from './../common/message-toast';
   import moment from 'moment';
 
   export default {
-    components: {
-      MessageToast
-    },
     methods: {
       showLayerPanel($event) {
         EventBus.$emit('show-layout-panel', $event);
@@ -79,12 +74,12 @@
           }
         }
       },
-      notificationType: {
-        type: String,
-        default() {
-          return 'default'
-        }
-      },
+        notificationType: {
+          type: String,
+          default() {
+            return 'default'
+          }
+        },
       layouts: {
         type: Array,
         default() {
@@ -128,10 +123,10 @@
     &__favorite-layouts {
       display: flex;
       width: 100%;
+      height: 7.1rem;
       overflow-x: scroll;
     }
     &__favorite-layout {
-      width: 5rem;
       margin-left: 1rem;
       text-align: center;
       &:first-child {
@@ -152,29 +147,22 @@
     }
 
     &__content {
-      .fc-composer--aside-l & {
-        padding-left: 32rem;
-      }
-      .fc-composer--aside-r & {
-        padding-right: 33rem;
-      }
       width: 100%;
+      height: 100%;
+      padding-top: 1rem;
     }
 
     &__h {
-      position: absolute;
-      left: 0;
-      width: 30rem;
+      width: 42rem;
       font-size: 1.8rem;
       color: $white;
     }
 
     &__right {
-      position: absolute;
-      right: 0;
       display: flex;
       flex-direction: column;
-      width: 26rem;
+      width: 34rem;
+      padding-left: 2.1rem;
       > div {
         color: $white;
         height: 3rem;

--- a/src/views/composer.vue
+++ b/src/views/composer.vue
@@ -12,6 +12,9 @@
       isRightVisible && 'fc-composer--aside-r',
     ]"
     >
+      <message-toast
+        :message="notification.message"
+        :type="notification.type"/>
       <composer-header
         :layouts="layoutModels"
         :notificationMessage="notification.message"
@@ -124,9 +127,11 @@
   import Layouts from './../components/content/layouts/layouts';
   import Layers from './../components/content/aside/layers/layers';
   import Modal from './../components/common/modal';
+  import MessageToast from './../components/common/message-toast';
 
   export default {
     components: {
+      MessageToast,
       ComposerHeader,
       Preview,
       ComposerAside,


### PR DESCRIPTION
컴포저에서 레이어 저장시 안내되는 메세지가 미리보기 영역을 침범하여 텍스트 메세지가 보이지 않음

전
![Screen Shot 2020-02-18 at 15 55 25](https://user-images.githubusercontent.com/15857404/74711640-dbbe1c80-5267-11ea-8c89-8953c8f4732d.png)

후
![Screen Shot 2020-02-19 at 15 14 38](https://user-images.githubusercontent.com/15857404/74807372-a3801200-532b-11ea-8762-6f19c1f9a435.png)
