### PR TITLE
편집창에서 요소별 구분 선 추가(V2-1023)

### DIFF
--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -220,13 +220,15 @@
   @import '../../assets/scss/utils/utilities';
   .fc-editor {
     position: relative;
-
     &__edit {
       /*display: none;*/
       position: relative;
       margin: 0 1.8rem 1.2rem;
     }
-
+    &__list-item:nth-child(1n + 2) {
+      border-top: 0.1rem solid #ff3232;
+      padding-top: 1.5rem;
+    }
     &__form {
       padding: 1.2rem 1.2rem;
       background-color: $dimmed;


### PR DESCRIPTION
편집창에서 요소 2개 이상 추가하는 경우 구분선을 추가합니다.
<img width="390" alt="Screen Shot 2020-09-16 at 14 07 54" src="https://user-images.githubusercontent.com/15857404/93294807-84485500-f826-11ea-8503-d21fdf033e70.png">
