### PR TITLE
컴포저 편집창에서 요소 사이의 border색상을 변경(V2-1022)

### DIFF
--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -226,7 +226,7 @@
       margin: 0 1.8rem 1.2rem;
     }
     &__list-item:nth-child(1n + 2) {
-      border-top: 0.1rem solid #ff3232;
+      border-top: 0.1rem solid #1976D2;
       padding-top: 1.5rem;
     }
     &__form {


### PR DESCRIPTION
https://fastcampus.atlassian.net/browse/V2-1022
9. 컴포저 카드 보더 색상 변경 -> #1976D2
<img width="407" alt="Screen Shot 2020-09-18 at 11 00 55" src="https://user-images.githubusercontent.com/15857404/93546666-42dab580-f99e-11ea-8a87-b16acfcd2f56.png">
