### PR TITLE
컴포저에서 디바이스별 보기를 추가(#199)

### DIFF
--- a/layouts/list/style.scss
+++ b/layouts/list/style.scss
@@ -1,5 +1,18 @@
-.fc-layout-heading {
+.fc-layout-list {
+  background-color: red;
   h1 {
-    color: red;
+    display: flex;
+    div {
+      color: red;
+    }
+    @media screen and (max-width: 599px) {
+      flex-direction: column;
+    }
+    @media screen and (min-width: 600px) and (max-width: 959px) {
+      flex-direction: column;
+    }
+    @media screen and (min-width: 960px) {
+      flex-direction: row;
+    }
   }
 }

--- a/layouts/styles.scss
+++ b/layouts/styles.scss
@@ -1,0 +1,9 @@
+@media screen and (max-width: 599px) {
+  .fc-block { background-color: orange; }
+}
+@media screen and (min-width: 600px) and (max-width: 959px) {
+  .fc-block { background-color: green; }
+}
+@media screen and (min-width: 960px) {
+  .fc-block { background-color: violet; }
+}

--- a/src/components/content/layouts/layouts.vue
+++ b/src/components/content/layouts/layouts.vue
@@ -80,7 +80,7 @@
   .fc-layout:before {
     position: absolute;
     bottom: 100%;
-    left: calc(50% - 1.2rem);
+    left: calc(50% + 1.2rem);
     height: 0;
     width: 0;
     margin-top: 0;

--- a/src/components/header/header.vue
+++ b/src/components/header/header.vue
@@ -17,6 +17,7 @@
         <span class="fc-header__save-time" v-show="saveTime">최종저장 시간: {{ saveTime }}</span>
       </div>
       <div class="fc-header__utils">
+        <button @click="onToggleDeviceMode"><span class="material-icons">devices</span></button>
         <button @click="showInfoTags"><i class="material-icons">help</i></button>
         <button class="fc-utils__btn" @click="showLayerPanel"><i class="material-icons">add</i></button>
         <button @click="validateLayer">
@@ -44,6 +45,9 @@
       },
       addLayer(layout) {
         EventBus.$emit('add-layer', layout);
+      },
+      onToggleDeviceMode() {
+        EventBus.$emit('toggle-device-mode');
       },
       getLayoutIds() {
         return JSON.parse(localStorage.getItem('favoriteLayouts')) || [];

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ import Composer from './views/composer.vue';
 
 import layouts from '../layouts';
 import sample from '../layouts/sample.json';
-import './../layouts/styles.scss';
+import '../layouts/styles.scss';
 
 new Vue({
   render(createElement) {

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ import Composer from './views/composer.vue';
 
 import layouts from '../layouts';
 import sample from '../layouts/sample.json';
+import './../layouts/styles.scss';
 
 new Vue({
   render(createElement) {

--- a/src/views/composer.vue
+++ b/src/views/composer.vue
@@ -126,11 +126,7 @@
       </div>
     </modal>
     <modal v-show="isDevicePreviewMode">
-      <div slot="main" class="fc-frame-wrapper" :class="{
-        'fc-frame-wrapper__desktop': deviceType === 'desktop',
-        'fc-frame-wrapper__mobile': deviceType === 'mobile',
-        'fc-frame-wrapper__tablet': deviceType === 'tablet'
-      }">
+      <div slot="main" class="fc-frame-wrapper" :class="`fc-frame-wrapper--${deviceType}`">
         <div class="fc-frame-wrapper__device-btns">
           <button @click="onChangeDevice('desktop')" :class="{'fc-frame-wrapper__selected': deviceType === 'desktop'}">
             <span class="material-icons">desktop_mac</span>
@@ -138,7 +134,7 @@
           <button @click="onChangeDevice('tablet')" :class="{'fc-frame-wrapper__selected': deviceType === 'tablet'}">
             <span class="material-icons">tablet_mac</span>
           </button>
-          <button @click="onChangeDevice('mobile')" :class="{'fc-frame-wrapper__selected': deviceType === 'mobile'}">
+          <button @click="onChangeDevice('phone')" :class="{'fc-frame-wrapper__selected': deviceType === 'phone'}">
             <span class="material-icons">phone_iphone</span>
           </button>
           <button @click="onToggleDeviceMode" style="margin-left: auto;">
@@ -520,13 +516,13 @@
       &__selected {
         color: #FF0000;
       }
-      &__desktop {
+      &--desktop {
         width: 100%;
       }
-      &__tablet {
+      &--tablet {
         width: 95.9rem;
       }
-      &__mobile {
+      &--phone {
         width: 59.9rem;
       }
       .fc-frame {

--- a/src/views/composer.vue
+++ b/src/views/composer.vue
@@ -125,6 +125,31 @@
         </table>
       </div>
     </modal>
+    <modal v-show="isDevicePreviewMode">
+      <div slot="main" class="fc-frame-wrapper" :class="{
+        'fc-frame-wrapper__desktop': deviceType === 'desktop',
+        'fc-frame-wrapper__mobile': deviceType === 'mobile',
+        'fc-frame-wrapper__tablet': deviceType === 'tablet'
+      }">
+        <div class="fc-frame-wrapper__device-btns">
+          <button @click="onChangeDevice('desktop')" :class="{'fc-frame-wrapper__selected': deviceType === 'desktop'}">
+            <span class="material-icons">desktop_mac</span>
+          </button>
+          <button @click="onChangeDevice('tablet')" :class="{'fc-frame-wrapper__selected': deviceType === 'tablet'}">
+            <span class="material-icons">tablet_mac</span>
+          </button>
+          <button @click="onChangeDevice('mobile')" :class="{'fc-frame-wrapper__selected': deviceType === 'mobile'}">
+            <span class="material-icons">phone_iphone</span>
+          </button>
+          <button @click="onToggleDeviceMode" style="margin-left: auto;">
+            <span class="material-icons">
+              close
+            </span>
+          </button>
+        </div>
+        <iframe class="fc-frame"></iframe>
+      </div>
+    </modal>
   </div>
 </template>
 
@@ -190,6 +215,7 @@
       EventBus.$on('show-layout-panel', this.onShowLayouts);
       EventBus.$on('clear', this.clearMessageToast);
       EventBus.$on('showInfoTags', this.onShowModal);
+      EventBus.$on('toggle-device-mode', this.onToggleDeviceMode);
       EventBus.$on('hidden', this.onToggleLayerState);
       EventBus.$on('validate-layer', this.onValidateLayer);
     },
@@ -237,7 +263,9 @@
             this.message = message;
             this.type = 'default';
           }
-        }
+        },
+        isDevicePreviewMode: false,
+        deviceType: 'desktop'
       };
     },
     methods: {
@@ -445,6 +473,23 @@
         // AS-IS: save generated html with source json
         this.$emit('save', layerHtml, layerJson);
       },
+      onToggleDeviceMode() {
+        this.isDevicePreviewMode = !this.isDevicePreviewMode;
+
+        if (this.isDevicePreviewMode) {
+          this.loadLayers();
+        }
+      },
+      loadLayers() {
+        const usedStyles = document.querySelectorAll("style[type='text/css']");
+        const doc = this.$el.getElementsByClassName('fc-frame')[0].contentWindow.document;
+
+        usedStyles.forEach(usedStyle => doc.head.appendChild(usedStyle.cloneNode(true)));
+        doc.body.innerHTML = this.layerHtml;
+      },
+      onChangeDevice(deviceType) {
+        this.deviceType = deviceType;
+      },
     },
     beforeDestroy() {
       EventBus.$off();
@@ -455,6 +500,42 @@
 <style lang="scss">
   @import './../assets/scss/style.scss';
 
+  .fc-modal-container {
+    main {
+      width: 100%;
+      height: 100vh;
+    }
+  }
+  .fc-modal-content {
+    height: 100%;
+    .fc-frame-wrapper {
+      text-align: center;
+      width: 60rem;
+      height: 100%;
+      margin: 0 auto;
+      &__device-btns {
+        display: flex;
+        justify-content: center;
+      }
+      &__selected {
+        color: #FF0000;
+      }
+      &__desktop {
+        width: 100%;
+      }
+      &__tablet {
+        width: 95.9rem;
+      }
+      &__mobile {
+        width: 59.9rem;
+      }
+      .fc-frame {
+        width: 100%;
+        height: 100%;
+        border-width: 0;
+      }
+    }
+  }
   .fc-tooltip {
     display: none;
     position: absolute;


### PR DESCRIPTION
컴포저 초기버전에서 구현된 레이어 미리보기를 기능을 추가합니다.
element 사이즈만으로는 미디어쿼리가 동작하지 않으므로 iframe을 별도로 추가하여 미리보기를 추가합니다.
css 컴포저의 css를 가져와 iframe에 다시 추가합니다.

desktop
![Screen Shot 2020-10-19 at 18 14 13](https://user-images.githubusercontent.com/15857404/96425490-09b09200-1237-11eb-91ad-56ef72293ff5.png)

tablet
![Screen Shot 2020-10-19 at 18 14 19](https://user-images.githubusercontent.com/15857404/96425508-103f0980-1237-11eb-9300-477c628321fa.png)

mobile
![Screen Shot 2020-10-19 at 18 14 28](https://user-images.githubusercontent.com/15857404/96425534-159c5400-1237-11eb-9594-c5d762ce6a82.png)
